### PR TITLE
Add the ability to change clear color and fog properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ obj/*
 bin/*
 .vs/*
 *.sln
+.idea

--- a/src/Draw.cs
+++ b/src/Draw.cs
@@ -26,10 +26,18 @@ namespace Disaster {
         public static int offsetY;
 
         public static Color32 clear = new Color32() { r=0, g=0, b=0, a=0 };
+        public static Color32 sceneClear = new Color32() { r=0, g=0, b=0, a=0 };
 
         public static int MaxTextLength()
         {
             return (textureWidth / fontWidth);
+        }
+
+        public static void SetClearColor(Color32 clr)
+        {
+            sceneClear = clr;
+            // LUNA: Override here just in case. Alpha of 1 will override 
+            sceneClear.a = 0;
         }
 
         public static string[] SplitLineToFitScreen(string message)

--- a/src/Draw.cs
+++ b/src/Draw.cs
@@ -26,18 +26,10 @@ namespace Disaster {
         public static int offsetY;
 
         public static Color32 clear = new Color32() { r=0, g=0, b=0, a=0 };
-        public static Color32 sceneClear = new Color32() { r=0, g=0, b=0, a=0 };
 
         public static int MaxTextLength()
         {
             return (textureWidth / fontWidth);
-        }
-
-        public static void SetClearColor(Color32 clr)
-        {
-            sceneClear = clr;
-            // LUNA: Override here just in case. Alpha of 1 will override 
-            sceneClear.a = 0;
         }
 
         public static string[] SplitLineToFitScreen(string message)

--- a/src/ObjRenderer.cs
+++ b/src/ObjRenderer.cs
@@ -17,12 +17,18 @@ namespace Disaster {
         public static Color32 fogColor;
         public static float fogStart = 16.0f;
         public static float fogDistance = 128.0f;
+        public static bool fogEnabled = false;
 
         public static void SetFogProperties(Color32 clr, float startDist, float dist)
         {
             fogColor = clr;
             fogStart = startDist;
             fogDistance = dist;
+        }
+
+        public static void SetFogEnabled(bool enabled)
+        {
+            fogEnabled = enabled;
         }
 
         //static Dictionary<int, ShaderProgram> shaderCache;
@@ -89,6 +95,7 @@ namespace Disaster {
                     currentShader = shaderHash;
                     renderQueue[i].shader["projection_matrix"].SetValue(Matrix4.CreatePerspectiveFieldOfView(1f, (float)320 / 240, 0.1f, 1000f));
                     
+                    renderQueue[i].shader["Use_Fog"]?.SetValue(fogEnabled);
 
                     System.Numerics.Vector3 fogColorV3 =
                         new Vector3(fogColor.r / 255.0f, fogColor.g / 255.0f, fogColor.b / 255.0f);

--- a/src/ObjRenderer.cs
+++ b/src/ObjRenderer.cs
@@ -93,9 +93,9 @@ namespace Disaster {
                     System.Numerics.Vector3 fogColorV3 =
                         new Vector3(fogColor.r / 255.0f, fogColor.g / 255.0f, fogColor.b / 255.0f);
                 
-                    renderQueue[i].shader["Fog_Color"].SetValue(fogColorV3);
-                    renderQueue[i].shader["Fog_Start"].SetValue(fogStart);
-                    renderQueue[i].shader["Fog_Distance"].SetValue(fogDistance);
+                    renderQueue[i].shader["Fog_Color"]?.SetValue(fogColorV3);
+                    renderQueue[i].shader["Fog_Start"]?.SetValue(fogStart);
+                    renderQueue[i].shader["Fog_Distance"]?.SetValue(fogDistance);
                 }
 
                 Gl.BindBufferToShaderAttribute(renderQueue[i].objFile.vertices, renderQueue[i].shader, "pos");

--- a/src/ObjRenderer.cs
+++ b/src/ObjRenderer.cs
@@ -14,6 +14,17 @@ namespace Disaster {
         public Texture texture;
         public Matrix4 transform;
 
+        public static Color32 fogColor;
+        public static float fogStart = 16.0f;
+        public static float fogDistance = 128.0f;
+
+        public static void SetFogProperties(Color32 clr, float startDist, float dist)
+        {
+            fogColor = clr;
+            fogStart = startDist;
+            fogDistance = dist;
+        }
+
         //static Dictionary<int, ShaderProgram> shaderCache;
         static int currentShader = -1;
 
@@ -23,6 +34,10 @@ namespace Disaster {
             this.texture = texture;
 
             transform = Matrix4.CreateTranslation(new Vector3(0, 0, -5));
+            
+            fogColor = new Color32(0, 0, 0, 255);
+            fogStart = 32.0f;
+            fogDistance = 96.0f;
         }
 
         public void Render()
@@ -73,6 +88,14 @@ namespace Disaster {
                     Gl.UseProgram(renderQueue[i].shader);
                     currentShader = shaderHash;
                     renderQueue[i].shader["projection_matrix"].SetValue(Matrix4.CreatePerspectiveFieldOfView(1f, (float)320 / 240, 0.1f, 1000f));
+                    
+
+                    System.Numerics.Vector3 fogColorV3 =
+                        new Vector3(fogColor.r / 255.0f, fogColor.g / 255.0f, fogColor.b / 255.0f);
+                
+                    renderQueue[i].shader["Fog_Color"].SetValue(fogColorV3);
+                    renderQueue[i].shader["Fog_Start"].SetValue(fogStart);
+                    renderQueue[i].shader["Fog_Distance"].SetValue(fogDistance);
                 }
 
                 Gl.BindBufferToShaderAttribute(renderQueue[i].objFile.vertices, renderQueue[i].shader, "pos");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -75,7 +75,7 @@ namespace Disaster
                 "Disaster Engine Again",
                 SDL.SDL_WINDOWPOS_UNDEFINED,
                 SDL.SDL_WINDOWPOS_UNDEFINED,
-                640, 480,
+                ScreenController.windowWidth, ScreenController.windowHeight,
                 SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL
             );
 

--- a/src/ScreenController.cs
+++ b/src/ScreenController.cs
@@ -101,6 +101,8 @@ namespace Disaster {
         public void Update() {
             Gl.BindFramebuffer(FramebufferTarget.Framebuffer, framebuffer);
             Gl.Viewport(0, 0, screenWidth, screenHeight);
+            Color32 clrColor = Draw.sceneClear;
+            Gl.ClearColor(clrColor.r / 255.0f, clrColor.g / 255.0f, clrColor.b / 255.0f, 255.0f);
             Gl.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
             ObjRenderer.RenderQueue();

--- a/src/ScreenController.cs
+++ b/src/ScreenController.cs
@@ -101,7 +101,7 @@ namespace Disaster {
         public void Update() {
             Gl.BindFramebuffer(FramebufferTarget.Framebuffer, framebuffer);
             Gl.Viewport(0, 0, screenWidth, screenHeight);
-            Color32 clrColor = Draw.sceneClear;
+            Color32 clrColor = sceneClear;
             Gl.ClearColor(clrColor.r / 255.0f, clrColor.g / 255.0f, clrColor.b / 255.0f, 255.0f);
             Gl.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
@@ -131,6 +131,15 @@ namespace Disaster {
         public void Done() {
             drawScreen.Dispose();
             
+        }
+
+        public static Color32 sceneClear = new Color32() { r=0, g=0, b=0, a=0 };
+
+        public static void SetClearColor(Color32 clr)
+        {
+            sceneClear = clr;
+            // LUNA: Override here just in case. Alpha of 1 will override 
+            sceneClear.a = 0;
         }
     }
 }

--- a/src/api/Draw.cs
+++ b/src/api/Draw.cs
@@ -2,7 +2,6 @@ using OpenGL;
 using Jurassic;
 using Jurassic.Library;
 using System.Numerics;
-using Disaster;
 
 namespace DisasterAPI
 {
@@ -29,17 +28,29 @@ namespace DisasterAPI
         [JSProperty(Name = "screenHeight")] public static int screenHeight { get { return Disaster.ScreenController.screenHeight; } }
         
         [JSFunction(Name = "setFog")]
-        public static void SetFogJS(ObjectInstance color, double fogStart, double fogDistance)
+        public static void SetFog(ObjectInstance color, double fogStart, double fogDistance)
         {
             var clr = Disaster.TypeInterface.Color32(color);
-            Disaster.ObjRenderer.SetFogProperties(clr, (float)fogStart, (float)fogDistance);    
+            Disaster.ObjRenderer.SetFogProperties(clr, (float)fogStart, (float)fogDistance);
+        }
+        
+        [JSFunction(Name = "enableFog")]
+        public static void EnableFog()
+        {
+            Disaster.ObjRenderer.SetFogEnabled(true);
+        }
+        
+        [JSFunction(Name = "disableFog")]
+        public static void DisableFog()
+        {
+            Disaster.ObjRenderer.SetFogEnabled(false);
         }
         
         [JSFunction(Name = "setClearColor")]
-        public static void SetClearColorJS(ObjectInstance color, double fogStart, double fogDistance)
+        public static void SetClearColor(ObjectInstance color, double fogStart, double fogDistance)
         {
             var clr = Disaster.TypeInterface.Color32(color);
-            Disaster.Draw.SetClearColor(clr);
+            Disaster.ScreenController.SetClearColor(clr);
         }
 
         [JSFunction(Name = "offset")]

--- a/src/api/Draw.cs
+++ b/src/api/Draw.cs
@@ -2,6 +2,8 @@ using OpenGL;
 using Jurassic;
 using Jurassic.Library;
 using System.Numerics;
+using Disaster;
+
 namespace DisasterAPI
 {
     
@@ -25,7 +27,20 @@ namespace DisasterAPI
         [JSProperty(Name = "fontWidth")] public static int fontWidth { get { return Disaster.Draw.fontWidth; } }
         [JSProperty(Name = "screenWidth")] public static int screenWidth { get { return Disaster.ScreenController.screenWidth; } }
         [JSProperty(Name = "screenHeight")] public static int screenHeight { get { return Disaster.ScreenController.screenHeight; } }
-
+        
+        [JSFunction(Name = "setFog")]
+        public static void SetFogJS(ObjectInstance color, double fogStart, double fogDistance)
+        {
+            var clr = Disaster.TypeInterface.Color32(color);
+            Disaster.ObjRenderer.SetFogProperties(clr, (float)fogStart, (float)fogDistance);    
+        }
+        
+        [JSFunction(Name = "setClearColor")]
+        public static void SetClearColorJS(ObjectInstance color, double fogStart, double fogDistance)
+        {
+            var clr = Disaster.TypeInterface.Color32(color);
+            Disaster.Draw.SetClearColor(clr);
+        }
 
         [JSFunction(Name = "offset")]
         public static void Offset(int x, int y)


### PR DESCRIPTION
The new API functions are Draw.setClearColor, Draw.setFog, Draw.enableFog and Draw.disableFog. Fog is disabled by default.
Example usage:
```
    var SkyColor = {r: 188, g: 148, b: 192};

    Draw.setClearColor(SkyColor);
    Draw.setFog(SkyColor, 16.0, 192.0);
```

Currently the fog properties cannot be enqueued, so they will affect the whole scene.