### PR TITLE
Bug fixes

### DIFF
--- a/disaster5/src/Program.cs
+++ b/disaster5/src/Program.cs
@@ -116,7 +116,7 @@ namespace Disaster
             Debug.enabled = false;
 
             Raylib.SetExitKey(KeyboardKey.KEY_HOME);
-            while (!Raylib.WindowShouldClose())
+            while (!Raylib.WindowShouldClose() && running)
             {
                 MusicController.Update();
                 Debug.FrameStart();

--- a/disaster5/src/api/Engine.cs
+++ b/disaster5/src/api/Engine.cs
@@ -34,6 +34,8 @@ namespace DisasterAPI
             Disaster.Assets.UnloadAll();
             Disaster.Assets.assignedDefaultShader = false;
             Disaster.ScreenController.instance.ReloadShader();
+            Raylib.StopSoundMulti();
+            Disaster.MusicController.StopMusic();
             Disaster.JS.instance.Reset();
         }
 


### PR DESCRIPTION
- Engine.quit() just sorta didn't actually do anything before so now it does.
- Any music or sound effects currently playing wouldn't be stopped on an Engine.reset(). Only the currently playing music is stopped now but the way things are setup you can only have one song playing anyway.